### PR TITLE
Simplify seen-set usage in HealthRegenController rescans

### DIFF
--- a/src/Features/HealthRegen/HealthRegenController.cs
+++ b/src/Features/HealthRegen/HealthRegenController.cs
@@ -149,14 +149,14 @@ internal static class HealthRegenController
 
     private static IEnumerable<UnitEntityData> GetConfiguredTargets(ModSettings settings)
     {
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var seen = new HashSet<UnitEntityData>();
         var baseTargets = settings.HealthRegen.IncludePets
             ? Game.Instance.Player.PartyAndPets
             : Game.Instance.Player.Party;
 
         foreach (var unit in baseTargets)
         {
-            if (ShouldInclude(unit) && seen.Add(unit.UniqueId))
+            if (ShouldInclude(unit) && seen.Add(unit))
             {
                 yield return unit;
             }
@@ -169,7 +169,7 @@ internal static class HealthRegenController
 
         foreach (var unit in Game.Instance.Player.AllCrossSceneUnits)
         {
-            if (ShouldIncludeSummon(unit) && seen.Add(unit.UniqueId))
+            if (ShouldIncludeSummon(unit) && !seen.Contains(unit))
             {
                 yield return unit;
             }


### PR DESCRIPTION
## Summary
Resolves #9

- Changed `HashSet<string>` to `HashSet<UnitEntityData>` — no need to use string IDs when unit references work directly
- First loop now uses `seen.Add(unit)` instead of `seen.Add(unit.UniqueId)`
- Second loop (summons) now uses `!seen.Contains(unit)` instead of `seen.Add(unit.UniqueId)` — since nothing iterates after the summons loop, there is no need to add to the set

## Test plan
- [x] Verify party members and pets are still included correctly
- [x] Verify summons are deduplicated and included when the setting is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)