### PR TITLE
Remove unnecessary nullable access in ResourceRegenFxPlayer

### DIFF
--- a/src/Features/ResourceRegen/ResourceRegenFxPlayer.cs
+++ b/src/Features/ResourceRegen/ResourceRegenFxPlayer.cs
@@ -11,7 +11,7 @@ internal static class ResourceRegenFxPlayer
 {
     public static void TryPlayOnUnit(ModLogger logger, ModSettings settings, UnitEntityData unit)
     {
-        if (!settings.ResourceRegen.ShowVisualEffects || unit?.View == null)
+        if (!settings.ResourceRegen.ShowVisualEffects || unit.View == null)
         {
             return;
         }


### PR DESCRIPTION
## Summary
Resolves #6

- Changed `unit?.View` to `unit.View` — `unit` is never null at this call site, so the null-conditional operator was misleading. Nullability should be intentional.

## Test plan
- [x] Verify visual effects still play on resource regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)