### PR TITLE
Expand spell level settings to support level 10

### DIFF
--- a/src/ModSettings.cs
+++ b/src/ModSettings.cs
@@ -62,6 +62,7 @@ public sealed class ResourceRegenSettings
     public float Level7IntervalSeconds = 120.0f;
     public float Level8IntervalSeconds = 150.0f;
     public float Level9IntervalSeconds = 180.0f;
+    public float Level10IntervalSeconds = 210.0f;
     public int GenericResourceRestoreAmount = 1;
     public float GenericTier1IntervalSeconds = 30.0f;
     public float GenericTier2IntervalSeconds = 40.0f;
@@ -95,8 +96,10 @@ public sealed class ResourceRegenSettings
                 return Level8IntervalSeconds;
             case 9:
                 return Level9IntervalSeconds;
+            case 10:
+                return Level10IntervalSeconds;
             default:
-                return spellLevel > 9 ? Level9IntervalSeconds : 0f;
+                return spellLevel > 10 ? Level10IntervalSeconds : 0f;
         }
     }
 

--- a/src/UI/SettingsRenderer.cs
+++ b/src/UI/SettingsRenderer.cs
@@ -50,6 +50,7 @@ internal static class SettingsRenderer
     private static string resourceLevel7IntervalText;
     private static string resourceLevel8IntervalText;
     private static string resourceLevel9IntervalText;
+    private static string resourceLevel10IntervalText;
     private static string resourceGenericRestoreAmountText;
     private static string resourceGenericTier1IntervalText;
     private static string resourceGenericTier2IntervalText;
@@ -278,6 +279,12 @@ internal static class SettingsRenderer
             resourceLevel9IntervalText,
             value => resourceLevel9IntervalText = value,
             settings.ResourceRegen.Level9IntervalSeconds);
+        DrawSpellLevelIntervalField(
+            settings,
+            10,
+            resourceLevel10IntervalText,
+            value => resourceLevel10IntervalText = value,
+            settings.ResourceRegen.Level10IntervalSeconds);
 
         GUILayout.Space(8f);
         Section("Generic Ability Resources");
@@ -487,6 +494,9 @@ internal static class SettingsRenderer
             case 9:
                 settings.ResourceRegen.Level9IntervalSeconds = updatedValue;
                 break;
+            case 10:
+                settings.ResourceRegen.Level10IntervalSeconds = updatedValue;
+                break;
         }
     }
 
@@ -554,6 +564,7 @@ internal static class SettingsRenderer
         resourceLevel7IntervalText ??= settings.ResourceRegen.Level7IntervalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
         resourceLevel8IntervalText ??= settings.ResourceRegen.Level8IntervalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
         resourceLevel9IntervalText ??= settings.ResourceRegen.Level9IntervalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
+        resourceLevel10IntervalText ??= settings.ResourceRegen.Level10IntervalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
         resourceGenericRestoreAmountText ??= settings.ResourceRegen.GenericResourceRestoreAmount.ToString(CultureInfo.InvariantCulture);
         resourceGenericTier1IntervalText ??= settings.ResourceRegen.GenericTier1IntervalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
         resourceGenericTier2IntervalText ??= settings.ResourceRegen.GenericTier2IntervalSeconds.ToString("0.###", CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary
Resolves #14

- Added `Level10IntervalSeconds = 210.0f` setting for spell level 10
- Added `case 10` to `GetIntervalSecondsForSpellLevel`
- Updated the fallback to use the level 10 interval for any spell level above 10
- Added the level 10 interval field to the settings UI

## Test plan
- [ ] Verify level 10 field appears in the settings UI
- [ ] Verify spellbooks with MaxSpellLevel > 9 now regenerate at the configured level 10 interval
- [ ] Verify levels 1-9 are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)